### PR TITLE
:tada:QdrantManagerの追加

### DIFF
--- a/dev/backend/app/services/QdrantManager.py
+++ b/dev/backend/app/services/QdrantManager.py
@@ -1,0 +1,28 @@
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import VectorParams, Distance
+import  dotenv
+import os
+import asyncio
+
+dotenv.load_dotenv()
+
+
+class QdrantManager:
+    def __init__(self, host: str = "localhost", port: int = 6333, ssl: bool = False):
+        self.client = QdrantClient(url=f"{'https' if ssl else 'http'}://{host}:{port}", api_key=os.getenv("QDRANT_API_KEY"))
+
+    def create_collection(self, collection_name: str):
+        self.client.recreate_collection(
+            collection_name=collection_name,
+            vectors_config={
+                "embedding": VectorParams(
+                    size=384,  # 例: OpenAIのtext-embedding-ada-002のベクトルサイズ
+                    distance=Distance.COSINE
+                )
+            }
+        )
+        print(f"Collection '{collection_name}' created successfully.")
+
+if __name__ == "__main__":
+    qdrant_manager = QdrantManager()
+    qdrant_manager.create_collection("example_collection")

--- a/dev/backend/pyproject.toml
+++ b/dev/backend/pyproject.toml
@@ -10,5 +10,6 @@ dependencies = [
     "firebase-admin>=6.7.0",
     "openai>=1.79.0",
     "python-dotenv>=1.1.0",
+    "qdrant-client>=1.14.2",
     "uvicorn>=0.34.1",
 ]


### PR DESCRIPTION
# 概要

Qdrantのコレクションをつくることができます。




# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->
- 現在使用しているqdrant-mcp-serverが複数のcollectionを扱えない。今後のためにつくったという感じです。
